### PR TITLE
Correct return type on Batch::indices

### DIFF
--- a/src/types/Batch.hpp
+++ b/src/types/Batch.hpp
@@ -132,7 +132,7 @@ public:
 	 * @param index_ Index of the sample from the batch.
 	 * @return Sample number.
 	 */
-	std::vector <size_t> indices(size_t index_) {
+	size_t indices(size_t index_) {
 		return sample_indices[index_];
 	}
 


### PR DESCRIPTION
Current Clang versions and GCC < 8 have ignored that the return type was wrong on this function, probably because of overeager SFINAE implementations, but it's a hard error on GCC 8.

This commit fixes compilation on Ubuntu 18.10.